### PR TITLE
expand percentiles, make interval configurable

### DIFF
--- a/lib/travis/metrics.rb
+++ b/lib/travis/metrics.rb
@@ -14,7 +14,12 @@ module Travis
           source = "#{source}.#{ENV['DYNO']}" if ENV.key?('DYNO')
           on_error = proc {|ex| puts "librato error: #{ex.message} (#{ex.response.body})"}
           puts "Using Librato metrics reporter (source: #{source}, account: #{email})"
-          Metriks::LibratoMetricsReporter.new(email, token, source: source, on_error: on_error)
+          Metriks::LibratoMetricsReporter.new(email, token,
+            source: source,
+            on_error: on_error,
+            percentiles: [0.95, 0.99, 0.999, 1.0],
+            interval: config[:interval],
+          )
         end
 
         def graphite(config, logger)


### PR DESCRIPTION
the available percentiles so far were p95 and p999. this patch expands that to also include p99 and max.

the default recording interval is 60 seconds. this means we only get one data point per minute. that
makes the feedback far from real time. by making this configurable (via the keychain), we can potentially reduce the interval to 10 seconds.

both of these changes may impact how much data we send to librato. adding 2 percentiles means all recorded latencies may have 2x data volume. lowering the interval from 60s to 10s will produce 6x the data valume.

we may want to consider collecting less individual metrics in some cases.

refs https://github.com/travis-ci/travis-gatekeeper/pull/264