### PR TITLE
expand percentiles, make interval configurable (take 2)

### DIFF
--- a/lib/travis/metrics.rb
+++ b/lib/travis/metrics.rb
@@ -35,19 +35,19 @@ module Travis
     end
 
     def count(key)
-      Metriks.counter(key).increment if reporter
+      Metriks.counter(key).increment
     end
 
     def meter(key)
-      Metriks.meter(key).mark if reporter
+      Metriks.meter(key).mark
     end
 
     def gauge(key, value)
-      Metriks.gauge(key).set(value) if reporter
+      Metriks.gauge(key).set(value)
     end
 
     def time(key, &block)
-      reporter ? Metriks.timer(key).time(&block) : yield
+      Metriks.timer(key).time(&block)
     end
   end
 end

--- a/lib/travis/metrics/reporter/librato.rb
+++ b/lib/travis/metrics/reporter/librato.rb
@@ -14,7 +14,12 @@ module Travis
         def setup
           return unless email && token
           logger.info MSGS[:setup] % [source, email]
-          @reporter = Metriks::LibratoMetricsReporter.new(email, token, source: source, on_error: method(:on_error))
+          @reporter = Metriks::LibratoMetricsReporter.new(email, token,
+            source: source,
+            on_error: method(:on_error),
+            percentiles: [0.95, 0.99, 0.999, 1.0],
+            interval: config[:interval],
+          )
           reporter.start
         end
 


### PR DESCRIPTION
the available percentiles so far were p95 and p999. this patch expands that to also include p99 and max.

the default recording interval is 60 seconds. this means we only get one data point per minute. that makes the feedback far from real time. by making this configurable (via the keychain), we can potentially reduce the interval to 10 seconds.

both of these changes may impact how much data we send to librato. adding 2 percentiles means all recorded latencies may have 2x data volume. lowering the interval from 60s to 10s will produce 6x the data valume.

we may want to consider collecting less individual metrics in some cases.

replaces travis-ci/travis-metrics#2

refs travis-ci/travis-gatekeeper#264