### PR TITLE
hdrhistogram: enable by default

### DIFF
--- a/lib/travis/metrics.rb
+++ b/lib/travis/metrics.rb
@@ -12,6 +12,8 @@ module Travis
       }
 
       def setup(config, logger)
+        Metriks.enable_hdrhistogram
+
         reporter = start(config, logger)
         logger.debug(MSGS[:no_reporter]) unless reporter
         new(reporter)


### PR DESCRIPTION
this will make it easier to roll out to all other apps.

refs https://github.com/travis-ci/travis-gatekeeper/pull/264