### PR TITLE
use HEROKU_APP_NAME env var as part of source if present

### DIFF
--- a/lib/travis/metrics/reporter/librato.rb
+++ b/lib/travis/metrics/reporter/librato.rb
@@ -34,7 +34,7 @@ module Travis
           end
 
           def source
-            [config[:source], dyno].compact.join('.')
+            [config[:source] || ENV['HEROKU_APP_NAME'], dyno].compact.join('.')
           end
 
           def dyno


### PR DESCRIPTION
This env var is provided automatically by heroku's dyno metadata feature:

```
heroku labs:enable runtime-dyno-metadata
```